### PR TITLE
Correcciones varias

### DIFF
--- a/modules/corpos.py
+++ b/modules/corpos.py
@@ -66,7 +66,8 @@ def valua_cupon_cero_corpo(id_bono, fecha_valuacion, fecha_vencimiento, vn, t_re
     
     dict_temp = {'fecha_cupon':[fecha_vencimiento], 
                  'plazo':[dias_restantes],
-                 'dias_cupon':[0]}
+                 'dias_cupon':[0],
+                 'factor_descuento':[factor_descuento]}
     
     df_out = pd.DataFrame(dict_temp)
         
@@ -306,7 +307,7 @@ def vp_flujo_corpo(vn, tasa_cupon, dias_cupon, n_cupon, n_total, t_rend, plazo, 
     
     
 
-    return vp
+    return vp, factor_descuento
 
 
 def valua_bono_corporativo(fecha_valuacion, fecha_vencimiento, periodo_cupon, calendario, convencion, tipo_tasa, vn, tasa_cupon, t_rend, tasa_mercado, sobre_tasa, dia_fijo, sobre_tasa_cupon):
@@ -367,31 +368,34 @@ def valua_bono_corporativo(fecha_valuacion, fecha_vencimiento, periodo_cupon, ca
     # Vectores auxiliares.
     vp_flujos = []
     plazos_next = []
+    factores_descuento = []
     
     for i in range(1, n_restantes + 1):
         
         # Valor presente del flujo i.
-        vp = vp_flujo_corpo(vn = vn,
-                      tasa_cupon = tasa_cupon,
-                      dias_cupon = df_fechas['dias_cupon'][i - 1],
-                      n_cupon = i,
-                      n_total = n_restantes,
-                      t_rend = t_rend, 
-                      plazo = df_fechas['plazo'][i - 1],
-                      tipo_tasa = tipo_tasa,
-                      tasa_mercado = tasa_mercado,
-                      sobre_tasa = sobre_tasa,
-                      sobre_tasa_cupon = sobre_tasa_cupon,
-                      convencion = convencion,
-                      cupones_anuales = cupones_anuales,
-                      periodo_cupon = periodo_cupon)
+        vp, factor_descuento = vp_flujo_corpo(vn = vn,
+                                              tasa_cupon = tasa_cupon,
+                                              dias_cupon = df_fechas['dias_cupon'][i - 1],
+                                              n_cupon = i,
+                                              n_total = n_restantes,
+                                              t_rend = t_rend, 
+                                              plazo = df_fechas['plazo'][i - 1],
+                                              tipo_tasa = tipo_tasa,
+                                              tasa_mercado = tasa_mercado,
+                                              sobre_tasa = sobre_tasa,
+                                              sobre_tasa_cupon = sobre_tasa_cupon,
+                                              convencion = convencion,
+                                              cupones_anuales = cupones_anuales,
+                                              periodo_cupon = periodo_cupon)
 
         # Plazo siguiente - se utiliza para el cálculo de la duración y convexidad.
         plazo_next = (df_fechas['plazo'][i - 1] / 365) * (df_fechas['plazo'][i - 1] / 365 + 1)
         
+        factores_descuento.append(factor_descuento)
         vp_flujos.append(vp)
         plazos_next.append(plazo_next)
         
+    df_fechas['factor_descuento'] = factores_descuento
     df_fechas['vp_flujo'] = vp_flujos
     df_fechas['plazo_next'] = plazos_next
     

--- a/modules/eurobonos.py
+++ b/modules/eurobonos.py
@@ -128,7 +128,7 @@ def vp_flujo_euro(vn, tipo_tasa, convencion, tasa_cupon, cupones_anuales, n_cupo
     vp = flujo * factor_descuento
     
     
-    return vp
+    return vp, factor_descuento
 
 
 def valua_eurobono(fecha_valuacion, fecha_vencimiento, calendario, periodo_cupon, convencion, dia_fijo, vn, tv, tasa_cupon, t_rend, tipo_tasa):
@@ -153,6 +153,7 @@ def valua_eurobono(fecha_valuacion, fecha_vencimiento, calendario, periodo_cupon
     # Vectores auxiliares.
     vp_flujos = []
     plazos_next = []
+    factores_descuento = []
     
     # Iteramos sobre todos los cupones restantes.
     
@@ -160,17 +161,17 @@ def valua_eurobono(fecha_valuacion, fecha_vencimiento, calendario, periodo_cupon
         
         # Valor presente del flujo i
         
-        vp = vp_flujo_euro(vn = vn,
-                           tipo_tasa = tipo_tasa,
-                           convencion = convencion,
-                           tasa_cupon = tasa_cupon,
-                           cupones_anuales = cupones_anuales,
-                           n_cupon = i,
-                           n_total = n_restantes,
-                           periodo_cupon = periodo_cupon,
-                           t_rend = t_rend,
-                           dias_cupon = df_fechas['dias_cupon'][i - 1],
-                           plazo = df_fechas['plazo'][i - 1])
+        vp, factor_descuento = vp_flujo_euro(vn = vn,
+                                             tipo_tasa = tipo_tasa,
+                                             convencion = convencion,
+                                             tasa_cupon = tasa_cupon,
+                                             cupones_anuales = cupones_anuales,
+                                             n_cupon = i,
+                                             n_total = n_restantes,
+                                             periodo_cupon = periodo_cupon,
+                                             t_rend = t_rend,
+                                             dias_cupon = df_fechas['dias_cupon'][i - 1],
+                                             plazo = df_fechas['plazo'][i - 1])
         
         
         
@@ -179,9 +180,12 @@ def valua_eurobono(fecha_valuacion, fecha_vencimiento, calendario, periodo_cupon
         plazo_next = (df_fechas['plazo'][i - 1] / 365) * (df_fechas['plazo'][i - 1] / 365 + 1)
         
         # Asignamos resultados
+        factores_descuento.append(factor_descuento)
         vp_flujos.append(vp)
         plazos_next.append(plazo_next)
         
+    
+    df_fechas['factor_descuento'] = factores_descuento
     df_fechas['vp_flujo'] = vp_flujos
     df_fechas['plazo_next'] = plazos_next
     

--- a/modules/eurobonos.py
+++ b/modules/eurobonos.py
@@ -219,8 +219,3 @@ def intereses_devengados_eurobono(vn, convencion, tasa_cupon, dias_devengado, pe
      
     return int_dev
     
-
-
-
-
-

--- a/modules/fechas.py
+++ b/modules/fechas.py
@@ -325,13 +325,25 @@ def genera_fechas_cupon(fecha_valuacion, fecha_vencimiento, calendario, periodo_
         
     df_out_aux = pd.DataFrame(out, columns = ['fecha_cupon', 'plazo', 'dias_cupon']).sort_values(by = ['fecha_cupon'], ascending = True)
     
+    # Revisamos que sólo haya 1 plazo negativo.
+    
+    n_negativos = len(df_out_aux[df_out_aux['plazo'] < 0])
+    
+    if n_negativos > 1:
+        
+        df_negativos_aux = df_out_aux[df_out_aux['plazo'] < 0].copy()
+        idx_negativos = df_negativos_aux.index[-1]
+        
+        df_out_aux = df_out_aux[df_out_aux.index.isin(range(idx_negativos + 1))]
+        
+    
     # Obtenemos la fecha del cupón previo a la fecha de valuación.
     
     fecha_c_previo_aux = df_out_aux['fecha_cupon'].iloc[0]
     
+    
     # Una vez que se obtiene la fecha cupón previa a la fecha de valuación
     # se construyen las fechas cupón efectivas.
-    
     
     # Forward ---
     
@@ -426,41 +438,3 @@ def mapea_cupones_anuales(periodo_cupon):
         pass
     
     return cupones_anuales
-        
-        
-                
-                
-
-            
-            
-    
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/modules/generales.py
+++ b/modules/generales.py
@@ -89,7 +89,7 @@ def genera_resultados(id_bono, isin, fecha_valuacion, fecha_vencimiento, periodo
     euros_cupon_cero = ['D2', 'D2SP', 'D3', 'D3SP', 'D7', 'D7SP', 'D8', 'D8SP']
     
     corpos_completo = ['2','71','73','75','90','91','91SP','92','93','93SP','94','94SP',
-                       '95','97','98','CD','D','D2','D7','D8','F','FSP','G','I','IL',
+                       '95','97','98','CD','D','F','FSP','G','I','IL',
                        'JE','J', 'JI','JSP','Q','QSP','R1']
     
     

--- a/modules/gubernamentales.py
+++ b/modules/gubernamentales.py
@@ -5,7 +5,6 @@ import datetime
 from bizdays import Calendar
 
 from modules.fechas import *
-#from Code.modules.fechas import *
 
 
 # ---- Calendarios ----

--- a/modules/gubernamentales.py
+++ b/modules/gubernamentales.py
@@ -5,6 +5,7 @@ import datetime
 from bizdays import Calendar
 
 from modules.fechas import *
+#from Code.modules.fechas import *
 
 
 # ---- Calendarios ----
@@ -78,7 +79,8 @@ def valua_cupon_cero(id_bono, fecha_valuacion, fecha_vencimiento, vn, tv, tipo_c
     
     dict_temp = {'fecha_cupon':[fecha_vencimiento], 
                  'plazo':[dias_restantes],
-                 'dias_cupon':[0]}
+                 'dias_cupon':[0],
+                 'factor_descuento':[factor_descuento]}
     
     df_out = pd.DataFrame(dict_temp)
         
@@ -305,7 +307,7 @@ def vp_flujo_gubernamental(vn, tasa_cupon, dias_cupon, n_cupon, n_total, t_rend,
     else:
         pass
 
-    return vp
+    return vp, factor_descuento
 
 # ---- Valuación Bonos Gubernamentales Mx ----
 
@@ -369,36 +371,41 @@ def valua_bono_gubernamental(fecha_valuacion, fecha_vencimiento, periodo_cupon, 
     # Vectores auxiliares.
     vp_flujos = []
     plazos_next = []
+    factores_descuento = []
     
     for i in range(1, n_restantes + 1):
         
         # Valor presente del flujo i.
-        vp = vp_flujo_gubernamental(vn = vn,
-                                    tasa_cupon = tasa_cupon,
-                                    dias_cupon = df_fechas['dias_cupon'][i - 1],
-                                    n_cupon = i,
-                                    n_total = n_restantes,
-                                    t_rend = t_rend, 
-                                    plazo = df_fechas['plazo'][i - 1],
-                                    tv = tv,
-                                    tipo_cambio = tipo_cambio,
-                                    tasa_mercado = tasa_mercado,
-                                    sobre_tasa = sobre_tasa,
-                                    fecha_valuacion = fecha_valuacion,
-                                    fecha_vencimiento = fecha_vencimiento,
-                                    calendario = calendario,
-                                    periodo_cupon = periodo_cupon,
-                                    convencion = convencion,
-                                    dia_fijo = dia_fijo)
+        vp, factor_descuento = vp_flujo_gubernamental(vn = vn,
+                                                      tasa_cupon = tasa_cupon,
+                                                      dias_cupon = df_fechas['dias_cupon'][i - 1],
+                                                      n_cupon = i,
+                                                      n_total = n_restantes,
+                                                      t_rend = t_rend, 
+                                                      plazo = df_fechas['plazo'][i - 1],
+                                                      tv = tv,
+                                                      tipo_cambio = tipo_cambio,
+                                                      tasa_mercado = tasa_mercado,
+                                                      sobre_tasa = sobre_tasa,
+                                                      fecha_valuacion = fecha_valuacion,
+                                                      fecha_vencimiento = fecha_vencimiento,
+                                                      calendario = calendario,
+                                                      periodo_cupon = periodo_cupon,
+                                                      convencion = convencion,
+                                                      dia_fijo = dia_fijo)
         
         # Plazo siguiente - se utiliza para el cálculo de la duración y convexidad.
         plazo_next = (df_fechas['plazo'][i - 1] / 365) * (df_fechas['plazo'][i - 1] / 365 + 1)
         
         vp_flujos.append(vp)
         plazos_next.append(plazo_next)
+        factores_descuento.append(factor_descuento)
         
+    
+    df_fechas['factor_descuento'] = factores_descuento
     df_fechas['vp_flujo'] = vp_flujos
     df_fechas['plazo_next'] = plazos_next
+    
     
     return df_fechas, fecha_c_previo
 
@@ -407,6 +414,19 @@ def valua_bono_gubernamental(fecha_valuacion, fecha_vencimiento, periodo_cupon, 
 
 
 
-
+#----
+# valua_bono_gubernamental(fecha_valuacion = '16/02/2022',
+#                          fecha_vencimiento = '05/09/2024',
+#                          periodo_cupon = 182, 
+#                          calendario = 'MXN',
+#                          convencion = 'actual/360',
+#                          tv = 'M',
+#                          vn = 100,
+#                          tipo_cambio = 1,
+#                          tasa_cupon = 0.08,
+#                          t_rend = 0.056496266,
+#                          tasa_mercado = 0,
+#                          sobre_tasa = 0,
+#                          dia_fijo = 'no')
 
 

--- a/pages/Bono_Individual.py
+++ b/pages/Bono_Individual.py
@@ -10,21 +10,20 @@ import os
 from modules.generales import *
 
 
-
 # ---- Helpers ---------
 
 # ---- [] TVs
 gubernamentales_cuponados = ['M', 'S','2U','PI', 'IM', 'IQ', 'IS', 'LD', 'LF']
 gubernamentales_cupon_cero = ['BI','MC','MP', 'SC', 'SP']
 
-euros_cuponados = ['D1', 'D1SP', 'D4', 'D4SP', 'D5', 'D5SP', 'D6', 'D6SP']
-euros_cupon_cero = ['D2', 'D2SP', 'D3', 'D3SP', 'D7', 'D7SP', 'D8', 'D8SP']
+euros_completo = ['D1', 'D1SP', 'D4', 'D4SP', 'D5', 'D5SP', 'D6', 'D6SP',
+                  'D2', 'D2SP', 'D3', 'D3SP', 'D7', 'D7SP', 'D8', 'D8SP']
 
 corpos_completo = ['2','71','73','75','90','91','91SP','92','93','93SP','94','94SP',
                    '95','97','98','CD','D','F','FSP','G','I','IL',
                    'JE','J', 'JI','JSP','Q','QSP','R1']
 
-all_tv = gubernamentales_cuponados + gubernamentales_cupon_cero + euros_cuponados + euros_cupon_cero + corpos_completo
+all_tv = gubernamentales_cuponados + gubernamentales_cupon_cero + euros_completo + corpos_completo
 all_tv = list(set(all_tv))
 
 # ---- [] Periodos Cupón
@@ -120,18 +119,20 @@ with st.sidebar.form(key = 'btn_data'):
     
     if select_type_yield == 'fija':
         
-        cupon_period = st.selectbox(label = "Periodo Cupón: ",
-                                    options = cupon_period_list,
-                                    index = 5)
+        select_coupon_rate = st.text_input(label = "Tasa Cupón: ",
+                                           value = "0.00",
+                                           help = "Tasa en %")
+        
+        select_coupon_rate = float(select_coupon_rate) / 100
+        
+        
             
         c7, c8 = st.columns(2)
         
         with c7:
-            select_coupon_rate = st.text_input(label = "Tasa Cupón: ",
-                                               value = "0.00",
-                                               help = "Tasa en %")
-            
-            select_coupon_rate = float(select_coupon_rate) / 100
+            cupon_period = st.selectbox(label = "Periodo Cupón: ",
+                                        options = cupon_period_list,
+                                        index = 5)
         
         with c8:
             select_fixed_day = st.selectbox(label = "Cupón en Día Fijo:",
@@ -148,20 +149,21 @@ with st.sidebar.form(key = 'btn_data'):
         
     # Si es tasa variable...
     elif select_type_yield == 'variable':
+        
+        select_coupon_rate = st.text_input(label = "Tasa Cupón: ",
+                                           value = "0.00",
+                                           help = "Tasa en %")
+        
+        select_coupon_rate = float(select_coupon_rate) / 100
     
-        cupon_period = st.selectbox(label = "Periodo Cupón: ",
-                                    options = cupon_period_list,
-                                    index = 5)
             
         c7, c8 = st.columns(2)
         
         
         with c7:
-            select_coupon_rate = st.text_input(label = "Tasa Cupón: ",
-                                               value = "0.00",
-                                               help = "Tasa en %")
-            
-            select_coupon_rate = float(select_coupon_rate) / 100
+            cupon_period = st.selectbox(label = "Periodo Cupón: ",
+                                        options = cupon_period_list,
+                                        index = 5)
         
         with c8:
             select_fixed_day = st.selectbox(label = "Cupón en Día Fijo:",
@@ -259,7 +261,7 @@ _, c11, _ = st.columns(3)
 
 with c11:
     btn_val = st.button("Realiza Valuación")
-    
+            
     
 if btn_val:
     

--- a/pages/Bono_Individual.py
+++ b/pages/Bono_Individual.py
@@ -9,10 +9,7 @@ import os
 
 from modules.generales import *
 
-from modules.corpos import *
-from modules.eurobonos import *
-from modules.gubernamentales import *
-from modules.generales import *
+
 
 # ---- Helpers ---------
 
@@ -24,7 +21,7 @@ euros_cuponados = ['D1', 'D1SP', 'D4', 'D4SP', 'D5', 'D5SP', 'D6', 'D6SP']
 euros_cupon_cero = ['D2', 'D2SP', 'D3', 'D3SP', 'D7', 'D7SP', 'D8', 'D8SP']
 
 corpos_completo = ['2','71','73','75','90','91','91SP','92','93','93SP','94','94SP',
-                   '95','97','98','CD','D','D2','D7','D8','F','FSP','G','I','IL',
+                   '95','97','98','CD','D','F','FSP','G','I','IL',
                    'JE','J', 'JI','JSP','Q','QSP','R1']
 
 all_tv = gubernamentales_cuponados + gubernamentales_cupon_cero + euros_cuponados + euros_cupon_cero + corpos_completo
@@ -68,19 +65,6 @@ with st.sidebar.form(key = 'btn_data'):
     select_yield_spread = 0
     select_coupon_spread = 0
     
-    
-    
-    
-    # Tipo Tasa
-    # select_type_yield = st.radio(label = "Tipo Tasa",
-    #                      options = ['Fija', 'Variable', 'Cero'],
-    #                      index = 0,
-    #                      help = 'La opción tasa cero aplica para los bonos corporativos que son valuados como un CETE.',
-    #                      horizontal = True)
-    
-    # select_type_yield = select_type_yield.lower()
-    #st.write(select_type_yield)
-
 
     # Fecha Valuación
     valuation_date = st.date_input("📅 Fecha Valuación:")
@@ -91,8 +75,10 @@ with st.sidebar.form(key = 'btn_data'):
     end_date = st.date_input("📅 Fecha Vencimiento:")
     end_date = str(end_date)
     end_date = end_date.split('-')
-        
-    # TV y Periodo Cupón
+    
+    # === Todos Comparten ===
+    
+    # TV y VN
     c1, c2 = st.columns(2)
     
     with c1:
@@ -102,59 +88,86 @@ with st.sidebar.form(key = 'btn_data'):
                                  help = 'Se encuentran listados todos los tipos valor documentados en los manuales de Valmer para eurobonos,gubernamentales y corporativos')
         
     with c2:
-        cupon_period = st.selectbox(label = "Periodo Cupón: ",
-                                    options = cupon_period_list,
-                                    index = 5)
-        
-    # VN y Día Fijo
-    c3, c4 = st.columns(2)
-    
-    with c3:
         face_value = st.text_input(label = "Nominal: ",
                                    value = "0.00")
         face_value = float(face_value)
         
-        
-    with c4:
-        select_fixed_day = st.selectbox(label = "Cupón en Día Fijo:",
-                                        options = ['Si', 'No'])
-        
-        select_fixed_day = select_fixed_day.lower()
-        
-    # Convención Días y Tipo de Cambio
-    c5, c6 = st.columns(2)
+    # Convencion Días y Tipo de cambio
+    c3, c4 = st.columns(2)
     
-    with c5:
+    with c3:
         select_daycount_convention = st.selectbox(label = "Convención Días: ",
                                                   options = daycount_list,
                                                   index = 2)
         
-    with c6:
+    with c4:
         exchange_rate = st.text_input(label = "Tipo de Cambio",
                                       value = "1.00")
         exchange_rate = float(exchange_rate)
         
     
-    # Tasa Rendimiento y Tasa Cupón    
-    c7, c8 = st.columns(2)
+        
+    # Tasa de rendimiento
     
-    with c7:
-        select_yield = st.text_input(label = "Tasa Rendimiento: ",
-                                     value = "0.00",
-                                     help = "Tasa en %")
+    select_yield = st.text_input(label = "Tasa Rendimiento: ",
+                                 value = "0.00",
+                                 help = "Tasa en %")
+    
+    select_yield = float(select_yield) / 100
+
+    
+    # === Tasa Fija ====
+    
+    if select_type_yield == 'fija':
         
-        select_yield = float(select_yield) / 100
+        cupon_period = st.selectbox(label = "Periodo Cupón: ",
+                                    options = cupon_period_list,
+                                    index = 5)
+            
+        c7, c8 = st.columns(2)
         
-    with c8:
-        select_coupon_rate = st.text_input(label = "Tasa Cupón: ",
-                                           value = "0.00",
-                                           help = "Tasa en %")
+        with c7:
+            select_coupon_rate = st.text_input(label = "Tasa Cupón: ",
+                                               value = "0.00",
+                                               help = "Tasa en %")
+            
+            select_coupon_rate = float(select_coupon_rate) / 100
         
-        select_coupon_rate = float(select_coupon_rate) / 100
+        with c8:
+            select_fixed_day = st.selectbox(label = "Cupón en Día Fijo:",
+                                            options = ['Si', 'No'])
+            
+            select_fixed_day = select_fixed_day.lower()
+            
+        market_yield = 0
+        select_coupon_spread = 0
+        rate_yield = select_yield
+                
+    
         
         
     # Si es tasa variable...
-    if select_type_yield == 'variable':
+    elif select_type_yield == 'variable':
+    
+        cupon_period = st.selectbox(label = "Periodo Cupón: ",
+                                    options = cupon_period_list,
+                                    index = 5)
+            
+        c7, c8 = st.columns(2)
+        
+        
+        with c7:
+            select_coupon_rate = st.text_input(label = "Tasa Cupón: ",
+                                               value = "0.00",
+                                               help = "Tasa en %")
+            
+            select_coupon_rate = float(select_coupon_rate) / 100
+        
+        with c8:
+            select_fixed_day = st.selectbox(label = "Cupón en Día Fijo:",
+                                            options = ['Si', 'No'])
+            
+            select_fixed_day = select_fixed_day.lower()
         
         
         # Sobretasa Mercado y Sobretasa Cupón
@@ -177,8 +190,16 @@ with st.sidebar.form(key = 'btn_data'):
         market_yield =  select_yield
         rate_yield = 0
         
-    # Si no es tasa variable...
+    # === Cupón Cero ====
     else:
+        
+        select_fixed_day = 'no'
+        select_coupon_rate = 0
+        cupon_period = 0
+        
+        select_yield_spread = 0
+        select_coupon_spread = 0
+        
         market_yield = 0
         select_coupon_spread = 0
         rate_yield = select_yield
@@ -290,6 +311,8 @@ if btn_val:
                                         'px_limpio':'Precio Limpio',
                                         'duracion':'Duracion',
                                         'convexidad':'Convexidad'})
+                      .style
+                      .format("{:.6f}")
             )
             
         with st.expander("Flujos Restantes"):
@@ -298,6 +321,7 @@ if btn_val:
                       .rename(columns = {'fecha_cupon':'Fecha Cupon',
                                         'plazo':'Plazo',
                                         'dias_cupon':'Dias Cupon',
+                                        'factor_descuento':'Factor Descuento',
                                         'vp_flujo':'VP Flujo'})
                       )
             

--- a/pages/Bonos_Multiples.py
+++ b/pages/Bonos_Multiples.py
@@ -146,6 +146,8 @@ if df_cartera_in:
                                     'px_limpio':'Precio Limpio',
                                     'duracion':'Duracion',
                                     'convexidad':'Convexidad'})
+                 .style
+                 .format("{:.6f}")
         )
     
     
@@ -169,6 +171,7 @@ if df_cartera_in:
                                'fecha_cupon':'Fecha Cupon',
                                'plazo':'Plazo',
                                'dias_cupon':'Dias Cupon',
+                               'factor_descuento':'Factor Descuento',
                                'vp_flujo':'VP Flujo'})
         )
         


### PR DESCRIPTION
- Se muestran 6 decimales en la tabla de valuación
- Se quitó de los corpos a los TVs D2, D7 y D8 para que se queden en los euros
- Corrección en los recuadros que se muestran cuando se selecciona tipo tasa fija, variable o cero
- Se agregó el campo de factor de descuento a la tabla de flujos
- Corrección en el módulo de fechas para cuando hay más de 1 plazo negativo